### PR TITLE
Fix for minor bug that caused GFF3ParseFile to classify some comment lines as records

### DIFF
--- a/lib/bio/db/gff/gff3parsefile.rb
+++ b/lib/bio/db/gff/gff3parsefile.rb
@@ -18,7 +18,7 @@ module Bio
           if s == '##FASTA'
             break
           end
-          next if s.length == 0 or s[0] == '#'
+          next if s.length == 0 or s ~= /^#/
           @records.push FastLineRecord.new(parse_line_fast(s))
         end
         fasta = Bio::GFF::FastaReader.new(fh)

--- a/lib/bio/db/gff/gff3parsefile.rb
+++ b/lib/bio/db/gff/gff3parsefile.rb
@@ -18,7 +18,7 @@ module Bio
           if s == '##FASTA'
             break
           end
-          next if s.length == 0 or s ~= /^#/
+          next if s.length == 0 or s =~ /^#/
           @records.push FastLineRecord.new(parse_line_fast(s))
         end
         fasta = Bio::GFF::FastaReader.new(fh)


### PR DESCRIPTION
Running rake test on my system ($ rvm use 1.9.2) throws a Bio::Log::FailOnErrorException:
Record should have 9 fields, but has 1 <##gff-version 3> <>

For some reason, the test s[0] == "#" isn't working (probably returning the char value rather than the char itself). The possible fixes are changing to s[0,1] == "#" or s =~ /^#/

I've changed it to the latter to match the same comment detection tests in gfffasta.rb and gfffileiterator.rb
