### PR TITLE
Using rvm and gff3-fetch script

### DIFF
--- a/bin/gff3-fetch
+++ b/bin/gff3-fetch
@@ -1,4 +1,4 @@
-#! /usr/bin/ruby
+#! /usr/bin/env ruby
 #
 # Author:: Pjotr Prins
 # Copyright:: August 2010


### PR DESCRIPTION
Tried to run gff3-fetch but couldn't because it's trying to run the ruby interpreter installed with ubuntu, even when I have rvm setup. Using "/usr/bin/env ruby" instead of "/usr/bin/ruby" fixes this.
